### PR TITLE
修复yaw和pitch数值异常导致的崩服卡服问题

### DIFF
--- a/src/main/java/cc/baka9/catseedlogin/bukkit/Config.java
+++ b/src/main/java/cc/baka9/catseedlogin/bukkit/Config.java
@@ -302,12 +302,12 @@ public class Config {
 
     // 修正Yaw数值防止崩服卡服
     private static float fixYaw(float yaw){
-        return yaw > 180 || yaw < -180 ? 0 : yaw;
+        return yaw > 180 || yaw < -180 ? 0 : (float)(Math.round(yaw * 100)) / 100;
     }
 
     // 修正Pitch数值防止崩服卡服
     private static float fixPitch(float pitch){
-        return pitch > 90 || pitch < -90 ? 0 : pitch;
+        return pitch > 90 || pitch < -90 ? 0 : (float)(Math.round(pitch * 100)) / 100;
     }
 
     // 获取默认世界

--- a/src/main/java/cc/baka9/catseedlogin/bukkit/Config.java
+++ b/src/main/java/cc/baka9/catseedlogin/bukkit/Config.java
@@ -276,8 +276,8 @@ public class Config {
             double x = Double.parseDouble(locStrs[1]);
             double y = Double.parseDouble(locStrs[2]);
             double z = Double.parseDouble(locStrs[3]);
-            float yaw = Float.parseFloat(locStrs[4]);
-            float pitch = Float.parseFloat(locStrs[5]);
+            float yaw = fixYaw(Float.parseFloat(locStrs[4]));
+            float pitch = fixPitch(Float.parseFloat(locStrs[5]));
             loc = new Location(world, x, y, z, yaw, pitch);
         } catch (Exception ignored) {
             loc = getDefaultWorld().getSpawnLocation();
@@ -287,13 +287,27 @@ public class Config {
     }
     // 位置转成字符串
     private static String loc2String(Location loc){
+        loc.setYaw(fixYaw(loc.getYaw()));
+        loc.setPitch(fixPitch(loc.getPitch()));
         try {
             return loc.getWorld().getName() + ":" + loc.getX() + ":" + loc.getY() + ":" + loc.getZ() + ":" + loc.getYaw() + ":" + loc.getPitch();
         } catch (Exception ignored) {
             loc = getDefaultWorld().getSpawnLocation();
         }
+        loc.setYaw(fixYaw(loc.getYaw()));
+        loc.setPitch(fixPitch(loc.getPitch()));
         return loc.getWorld().getName() + ":" + loc.getX() + ":" + loc.getY() + ":" + loc.getZ() + ":" + loc.getYaw() + ":" + loc.getPitch();
 
+    }
+
+    // 修正Yaw数值防止崩服卡服
+    private static float fixYaw(float yaw){
+        return yaw > 180 || yaw < -180 ? 0 : yaw;
+    }
+
+    // 修正Pitch数值防止崩服卡服
+    private static float fixPitch(float pitch){
+        return pitch > 90 || pitch < -90 ? 0 : pitch;
     }
 
     // 获取默认世界


### PR DESCRIPTION
之前我服经常玩家进服后服务器莫名卡住崩服
我一路排查下来发现Catseedlogin储存玩家下线位置的Yaw和Pitch数值异常
![`E~U7$_KOF27RD5$X`BA1CX](https://user-images.githubusercontent.com/92320175/194488043-ca4fb7ed-f57d-48a0-a5d9-7354e8882e9a.png)
虽然到现在都没查清根本原因(目前判断可能和ProtocolSupport插件有关系)
但是限制Yaw和Pitch范围应该能解决这个问题

追加:
还有这种数值,虽然不会卡服,但是会使玩家无法进入服务器
![image](https://user-images.githubusercontent.com/92320175/194500205-98e72e01-cb94-4736-ba65-003326db1b4d.png)

